### PR TITLE
Ajout des entités par défaut dans le code

### DIFF
--- a/headers/entite.h
+++ b/headers/entite.h
@@ -132,6 +132,13 @@ public:
 	*/
 	bool is_personnage();
 
+	//! Identification monstre
+	/*!
+	Permet de déterminer la qualité de monstre d'une entité.
+	\return Booléen: vrai si l'entité est un monstre, faux sinon
+	*/
+	bool is_monstre();
+
 	//! Affichage en détail
 	void afficher_detail();
 

--- a/headers/io.h
+++ b/headers/io.h
@@ -325,6 +325,94 @@ namespace io
 	template<typename T> std::vector<T> loadAllEntiteFromFile(T temp, std::string nomFichier)
 	{
 		std::vector<T> allEntite; //Vecteur de retour
+		
+		T test;
+
+		if (test.is_personnage()) //Création des personnages par défaut
+		{
+			std::vector<competence> lesCompetences;
+			
+			//Personnage Raph
+			competence une("Coup de clavier", 30, 20);
+			lesCompetences.push_back(une);
+			competence deux("C'est magique", 50, 50);
+			lesCompetences.push_back(deux);
+			competence trois("Trop vieux pour ces conneries", -15, 20);
+			lesCompetences.push_back(trois);
+			competence quatre("Coup de stylo", 5, -10);
+			lesCompetences.push_back(quatre);
+			T raph("p00", "Raph", 120, 20, 100, "Raph l'ancetre", lesCompetences);
+			allEntite.push_back(raph);
+			lesCompetences.clear(); //Vidage du vecteur de compétences
+
+			//Personnage Thibault
+			competence unee("Flip Keyboard", 20, 10);
+			lesCompetences.push_back(unee);
+			competence deuxx("Flip table", 60, 55);
+			lesCompetences.push_back(deuxx);
+			competence troixx("Recharge de sel", -10, 15);
+			lesCompetences.push_back(troixx);
+			competence quatree("Appel du Macbook", 7, -10);
+			lesCompetences.push_back(quatree);
+			T thibault("p01", "Thibault", 150, 15, 100, "Too salty", lesCompetences);
+			allEntite.push_back(thibault);
+			lesCompetences.clear(); //Vidage du vecteur de compétences
+
+			//Personnage Bobby
+			competence uneee("Attaque rapide", 15, 5);
+			lesCompetences.push_back(uneee);
+			competence deuxxx("Attaque chargée", 70, 65);
+			lesCompetences.push_back(deuxxx);
+			competence troixxx("Need healing", -15, 70);
+			lesCompetences.push_back(troixxx);
+			competence quatreee("Need more mana", 5, -20);
+			lesCompetences.push_back(quatreee);
+			T bobby("p02", "Bobby", 90, 30, 95, "Bobby ftw", lesCompetences);
+			allEntite.push_back(bobby);
+			lesCompetences.clear();
+
+			personnage::nbElemProt = 3;
+		}
+
+		if (test.is_monstre()) //Création des personnages par défaut
+		{
+			std::vector<competence> lesCompetences;
+
+			//Monstre Orc
+			competence une("Coup hache", 30, 0);
+			lesCompetences.push_back(une);
+			competence deux("Coup de marteau", 22, 0);
+			lesCompetences.push_back(deux);
+			competence trois("Coup de fouet", 15, 0);
+			lesCompetences.push_back(trois);
+			T orc("m00", "Orc", 95, 10, 0, "", lesCompetences);
+			allEntite.push_back(orc);
+			lesCompetences.clear(); //Vidage du vecteur de compétences
+
+			//Monstre Gobelin
+			competence unee("Vol d'argent", 15, 0);
+			lesCompetences.push_back(unee);
+			competence deuxx("Fabrication d'explosifs", 30, 0);
+			lesCompetences.push_back(deuxx);
+			competence troixx("Fourberie", 20, 0);
+			lesCompetences.push_back(troixx);
+			T gobelin("m01", "Gobelin", 90, 20, 0, "", lesCompetences);
+			allEntite.push_back(gobelin);
+			lesCompetences.clear(); //Vidage du vecteur de compétences
+
+			//Monstre elfe
+			competence uneee("Tir à l'arc", 25, 0);
+			lesCompetences.push_back(uneee);
+			competence deuxxx("Vision d'aigle", 15, 0);
+			lesCompetences.push_back(deuxxx);
+			competence troixxx("Magie elfique", 20, 0);
+			lesCompetences.push_back(troixxx);
+			T elfe("m02", "Elfe", 85, 18, 0, "", lesCompetences);
+			allEntite.push_back(elfe);
+			lesCompetences.clear();
+
+			monstre::nbElemProt = 3;
+		}
 
 		std::string uneLigne=""; //Variable stockant une ligne
 

--- a/headers/monstre.h
+++ b/headers/monstre.h
@@ -43,6 +43,8 @@ public:
 	*/
 	monstre(std::string entiteId, std::string entiteName, int entiteHpMax, int entiteSpeed, int entiteManaMax, std::string entiteDescription, std::vector<competence> allSkills) : entite(entiteId, entiteName, entiteHpMax, entiteSpeed, entiteManaMax, entiteDescription, allSkills){};
 
+
+	void printMonstre();
 };
 
 #endif // MONSTRE_H

--- a/sources/entite.cpp
+++ b/sources/entite.cpp
@@ -201,6 +201,15 @@ bool entite::is_personnage()
 	return false;
 }
 
+bool entite::is_monstre()
+{
+	if (getID().substr(0, 1) == "m")
+	{
+		return true;
+	}
+	return false;
+}
+
 entite entite::enleverVie(int degats)
 {
 	this->entiteHpCurrent-=degats;

--- a/sources/fichierMonstre.txt
+++ b/sources/fichierMonstre.txt
@@ -1,3 +1,1 @@
-m0/Orc/95/10/Coup de hache(30_0):Coup de marteau(22_0):Coup de fouet(15_0):|0||
-m1/Gobelin/90/20/Vol d'argent(15_0):Fabrication d'explosifs(30_0):Fourberie(20_0):|0||
-m2/Elfe/85/18/Tir à l'arc(25_0):Vision d'aigle(15_0):Magie elfique(20_0):|0||
+m0/Monstre/95/10/Competence 1(30_0):Competence 2(22_0):Competence 3(15_0):|0||

--- a/sources/fichierPersonnage.txt
+++ b/sources/fichierPersonnage.txt
@@ -1,3 +1,1 @@
-p0/Raph/100/20/Coup de clavier(30_20):C'est magique(50_50):Trop vieux pour ces conneries(-15_20):Coup de stylo(5_-10):|100|Raph l'ancetre|
-p1/Thibault/130/15/Flip keyboard(20_10):Flip table(60_55):Recharge de sel(-10_15):Appel du Macbook(7_-10):|100|Too much salt|
-p2/Bobby/90/30/Attaque rapide(15_5):Attaque chargée(70_65):Need Healing(-15_70):Need more mana(5_-20):|95|Bobby ftw|
+p0/Personnage/100/20/Competence 1(30_20):Competence 2(50_50):Competence 3(-15_20):Competence 4 (5_-10):|100|Bonjour, je suis un personnage de test et je suis inutile|

--- a/sources/monstre.cpp
+++ b/sources/monstre.cpp
@@ -4,7 +4,7 @@
 
 using namespace std;
 
-int monstre::nbElemProt = 3;
+int monstre::nbElemProt = 0;
 
 monstre::monstre()
 {

--- a/sources/personnage.cpp
+++ b/sources/personnage.cpp
@@ -3,7 +3,7 @@
 
 using namespace std;
 
-int personnage::nbElemProt = 3;
+int personnage::nbElemProt = 0;
 
 personnage::personnage()
 {


### PR DESCRIPTION
Encrage des entités par défaut directement dans la fonction de chargement d'entité.
Ajout d'une fonction permettant de savoir si une entité est un monstre.
Modif des fichiers txt pour éviter de charger les entités par défaut en double. Rajout d'une ligne "inutile" dans les fichiers pour pouvoir tester la lecture de fichier.